### PR TITLE
filtering by tool name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,6 @@ ENABLE_PROXY_API_TOOL=false
 # ACTION_KIT_BASE_URL="http://localhost:1721"
 # CONNECT_SDK_CDN_URL="http://localhost:4060/ui/scripts/sdk.js"
 
-# Uncomment to limit available tools to specific integrations
+# Uncomment to limit available tools to specific integrations and/or specific tools
 # LIMIT_TO_INTEGRATIONS=hubspot,salesforce,custom.spotify
+# LIMIT_TO_TOOLS=SLACK_SEND_MESSAGE,GOOGLE_DRIVE_LIST_FILES

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Set up the environment variables as described below:
   - `SIGNING_KEY_PATH`: Path to your JWT signing key file (required if SIGNING_KEY is not set)
 - Optional:
   - `LIMIT_TO_INTEGRATIONS`: Comma-separated list of integration names to limit the types of available tools.
+  - `LIMIT_TO_TOOLS`: Comma-separated list of tool names to additionaly limit available tools if needed.
   - `PORT`: Server port (default: 3001)
   - `MCP_SERVER_URL`: The URL of your hosted MCP Server. This will be used to generate Setup Links when your users are prompted to install integrations. (default: `http://localhost:3001`)
   - `CONNECT_SDK_CDN_URL`: Paragon Connect SDK CDN URL (default: https://cdn.useparagon.com/latest/sdk/index.js)

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,32 +128,21 @@ async function main() {
   console.log(`Server is running on`, `http://localhost:${envs.PORT}`);
 }
 
+const handleShutdown = async () => {
+  console.log("Closing all transports...");
+  await Promise.all(
+    Object.values(transports).map(async (transport) => {
+      await transport.transport.close();
+    })
+  );
+  await server.close();
+  for (const key in transports) {
+    delete transports[key];
+  }
+  process.exit(0);
+};
+
+process.on("SIGTERM", handleShutdown);
+process.on("SIGINT", handleShutdown);
+
 main();
-
-process.on("SIGTERM", async () => {
-  console.log("Closing all transports...");
-  await Promise.all(
-    Object.values(transports).map(async (transport) => {
-      await transport.transport.close();
-    })
-  );
-  await server.close();
-  for (const key in transports) {
-    delete transports[key];
-  }
-  process.exit(0);
-});
-
-process.on("SIGINT", async () => {
-  console.log("Closing all transports...");
-  await Promise.all(
-    Object.values(transports).map(async (transport) => {
-      await transport.transport.close();
-    })
-  );
-  await server.close();
-  for (const key in transports) {
-    delete transports[key];
-  }
-  process.exit(0);
-});

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -125,7 +125,7 @@ export async function loadCustomOpenApiTools(
           const toolName = `${item.integrationName
             .split(".")
             .join("_")
-            .toUpperCase()}_${requestName.split(" ").join("_").toUpperCase()}`;
+            .toUpperCase()}_${requestName.split(" ").join("_").replace(/(\r\n|\n|\r)/g, "").toUpperCase()}`;
 
           openApiRequests[toolName] = {
             baseUrl: spec.servers?.[0]?.url,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -125,7 +125,7 @@ export async function loadCustomOpenApiTools(
           const toolName = `${item.integrationName
             .split(".")
             .join("_")
-            .toUpperCase()}_${requestName.split(" ").join("_").replace(/(\r\n|\n|\r)/g, "").toUpperCase()}`;
+            .toUpperCase()}_${requestName.split(" ").join("_").toUpperCase()}`;
 
           openApiRequests[toolName] = {
             baseUrl: spec.servers?.[0]?.url,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -36,9 +36,9 @@ async function getAndProcessTools(
   const allTools = dynamicTools.concat(extraTools);
 
   return allTools.filter((tool) => {
-    let keep = false;
+    let keep = true;
     if (envs.LIMIT_TO_INTEGRATIONS && envs.LIMIT_TO_INTEGRATIONS.length > 0) {
-      keep = envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName)
+      keep = keep && envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName)
     }
     if (envs.LIMIT_TO_TOOLS && envs.LIMIT_TO_TOOLS.length > 0) {
       keep = keep && envs.LIMIT_TO_TOOLS.includes(tool.integrationName)

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -37,7 +37,6 @@ async function getAndProcessTools(
 
   return allTools.filter((tool) => {
     let keep = true;
-    console.log(tool);
     if (envs.LIMIT_TO_INTEGRATIONS && envs.LIMIT_TO_INTEGRATIONS.length > 0) {
       keep = keep && envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName);
     }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -37,11 +37,12 @@ async function getAndProcessTools(
 
   return allTools.filter((tool) => {
     let keep = true;
+    console.log(tool);
     if (envs.LIMIT_TO_INTEGRATIONS && envs.LIMIT_TO_INTEGRATIONS.length > 0) {
-      keep = keep && envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName)
+      keep = keep && envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName);
     }
     if (envs.LIMIT_TO_TOOLS && envs.LIMIT_TO_TOOLS.length > 0) {
-      keep = keep && envs.LIMIT_TO_TOOLS.includes(tool.integrationName)
+      keep = keep && envs.LIMIT_TO_TOOLS.includes(tool.name);
     }
     return keep;
   });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -34,14 +34,17 @@ async function getAndProcessTools(
 ): Promise<Array<ExtendedTool>> {
   const dynamicTools = await getTools(jwt);
   const allTools = dynamicTools.concat(extraTools);
-  
-  if (envs.LIMIT_TO_INTEGRATIONS && envs.LIMIT_TO_INTEGRATIONS.length > 0) {
-    return allTools.filter((tool) =>
-      envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName)
-    );
-  }
-  
-  return allTools;
+
+  return allTools.filter((tool) => {
+    let keep = false;
+    if (envs.LIMIT_TO_INTEGRATIONS && envs.LIMIT_TO_INTEGRATIONS.length > 0) {
+      keep = envs.LIMIT_TO_INTEGRATIONS.includes(tool.integrationName)
+    }
+    if (envs.LIMIT_TO_TOOLS && envs.LIMIT_TO_TOOLS.length > 0) {
+      keep = keep && envs.LIMIT_TO_TOOLS.includes(tool.integrationName)
+    }
+    return keep;
+  });
 }
 
 export function registerTools({
@@ -70,7 +73,7 @@ export function registerTools({
       if (sessionData.cachedTools) {
         return { tools: sessionData.cachedTools };
       }
-      
+
       const filteredTools = await getAndProcessTools(sessionData.currentJwt, extraTools);
       transports[sessionId].cachedTools = filteredTools;
       return { tools: filteredTools };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,16 @@ export const envs = z
           .map((s) => s.trim())
           .filter(Boolean)
       ),
+    LIMIT_TO_TOOLS: z
+      .string()
+      .default("")
+      .transform((val) =>
+        val
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      ),
+
   })
   .parse(process.env);
 
@@ -78,18 +88,16 @@ export async function performOpenApiAction(
     throw new Error(`No request found for action ${action.name}`);
   }
 
-  const resolvedRequestPath = `${
-    request.baseUrl ? request.baseUrl : ""
-  }${request.path.replace(
-    /\{(\w+)\}/g,
-    (_match: string, p1: string) => actionParams.params[p1]
-  )}`;
+  const resolvedRequestPath = `${request.baseUrl ? request.baseUrl : ""
+    }${request.path.replace(
+      /\{(\w+)\}/g,
+      (_match: string, p1: string) => actionParams.params[p1]
+    )}`;
 
   let url;
   if (action.integrationName.startsWith("custom.")) {
-    url = `https://proxy.useparagon.com/projects/${
-      envs.PROJECT_ID
-    }/sdk/proxy/custom/${action.integrationId!}`;
+    url = `https://proxy.useparagon.com/projects/${envs.PROJECT_ID
+      }/sdk/proxy/custom/${action.integrationId!}`;
   } else {
     url = `https://proxy.useparagon.com/projects/${envs.PROJECT_ID}/sdk/proxy/${action.integrationName}`;
   }
@@ -374,11 +382,11 @@ export async function performProxyApiRequest(
   const isCustomIntegration = args.integration.includes("custom.");
   const queryStr = args.queryParams
     ? `?${new URLSearchParams(
-        Object.entries(args.queryParams).reduce((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {} as Record<string, string>)
-      ).toString()}`
+      Object.entries(args.queryParams).reduce((acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      }, {} as Record<string, string>)
+    ).toString()}`
     : "";
 
   let path;


### PR DESCRIPTION
certain integrations like salesforce have 40+ tools, which can even cause models like gemini and gpt-4.1 to run into input token limits
- added ability to filter by tool names (in addition to integration)
- added a SIGINT condition for killing process with <ctrl+c>