### PR TITLE
Add Streamable HTTP transport with legacy SSE fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,17 @@ ENABLE_CUSTOM_OPENAPI_ACTIONS=false
 ENABLE_PROXY_API_TOOL=false
 ENABLE_CUSTOM_TOOL=false
 
+# Legacy HTTP+SSE endpoints remain available unless explicitly disabled
+ENABLE_LEGACY_SSE=true
+
+# Additional comma-separated hosts and origins accepted by the /mcp endpoint
+# MCP_ALLOWED_HOSTS="mcp.example.com"
+# MCP_ALLOWED_ORIGINS="https://app.example.com"
+
+# Streamable HTTP sessions expire after 30 minutes of inactivity by default
+# MCP_SESSION_IDLE_TIMEOUT_MS=1800000
+# MCP_MAX_SESSIONS=1000
+
 # Uncomment and update if using an on-premise Paragon instance
 # ACTIONKIT_BASE_URL="https://worker-actionkit.your-paragon-instance.url"
 # CONNECT_SDK_CDN_URL="https://connect.your-paragon-instance.url/ui/scripts/sdk.js"

--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ For testing, you can one-click deploy the server through Heroku.
 
 ### Authorization
 
-The `/mcp` endpoint accepts an `Authorization` header with a Paragon User Token as the Bearer token. Streamable HTTP clients must retain and send the same token used to initialize the session on every subsequent `GET`, `POST`, or `DELETE` request. If the token is rotated, initialize a new session. The legacy `GET /sse` endpoint also accepts this header when legacy SSE is enabled.
+The `/mcp` endpoint accepts an `Authorization` header with a Paragon User Token as the Bearer token. Streamable HTTP clients must retain and send the same token used to initialize the session on every subsequent `GET` or `POST` request. If the token is rotated, initialize a new session. A client may terminate its old session with `DELETE` using a rotated, unexpired token for the same user. The legacy `GET /sse` endpoint also accepts this header when legacy SSE is enabled.
 
 The Paragon User Token is an RS256-encoded JWT that is verified using the public key stored by Paragon. Your MCP client (e.g. your application server or the service running your AI agent) will sign the User Token using the matching private key generated in the Paragon dashboard, which only your server has access to.
 
 This allows the MCP to validate the authenticity of the requesting user using the JWT signature and public key. Once authenticated, the MCP will associate the user ID encoded in the JWT with the active MCP session.
 
-Streamable HTTP sessions are stored in memory and expire after 30 minutes of inactivity by default. Clients must initialize a new session after expiration or a server restart. Deployments with multiple server instances must use session affinity so requests bearing the same `Mcp-Session-Id` reach the instance that created it.
+Streamable HTTP sessions are stored in memory and close when their initializing token expires or after 30 minutes of inactivity by default. Clients must initialize a new session after expiration or a server restart. Deployments with multiple server instances must use session affinity so requests bearing the same `Mcp-Session-Id` reach the instance that created it.
 
 ## Adding Custom Actions with OpenAPI
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ Set up the environment variables as described below:
   - `ZEUS_BASE_URL`: Paragon API base URL (default: https://zeus.useparagon.com)
   - `PROXY_BASE_URL`: Paragon Proxy API base URL (default: https://proxy.useparagon.com)
   - `NODE_ENV`: Node environment (default: `development`)
-    <sub>**Note**: When `NODE_ENV` is set to `development`, the `/sse` parameter accepts any user ID in the `?user=` query parameter to automatically authorize as a specific user while testing locally.</sub>
+    <sub>**Note**: When `NODE_ENV` is set to `development`, the `/mcp` and `/sse` endpoints accept any user ID in the `?user=` query parameter to automatically authorize as a specific user while testing locally.</sub>
+  - `ENABLE_LEGACY_SSE`: Set to `false` to remove the deprecated `/sse` and `/messages` endpoints (default: `true`)
+  - `MCP_ALLOWED_HOSTS`: Additional comma-separated `Host` header values accepted by `/mcp`. The host from `MCP_SERVER_URL` is allowed automatically.
+  - `MCP_ALLOWED_ORIGINS`: Additional comma-separated `Origin` header values accepted by `/mcp`. The origin from `MCP_SERVER_URL` is allowed automatically.
+  - `MCP_SESSION_IDLE_TIMEOUT_MS`: Time in milliseconds before an inactive Streamable HTTP session is closed (default: `1800000`)
+  - `MCP_MAX_SESSIONS`: Maximum number of concurrent Streamable HTTP sessions per server instance (default: `1000`)
 
 ### Running the Server
 
@@ -91,7 +96,7 @@ To use this MCP server with Cursor, add the following to your Cursor configurati
 {
   "mcpServers": {
     "mcp-actionkit-dev": {
-      "url": "http://localhost:3001/sse?user=[user-id]"
+      "url": "http://localhost:3001/mcp?user=[user-id]"
     }
   }
 }
@@ -111,7 +116,7 @@ To use this MCP server with Claude, add the following to your Claude configurati
   "mcpServers": {
     "actionkit": {
       "command": "npx",
-      "args": ["mcp-remote", "http://localhost:3001/sse?user=[user-id]"]
+      "args": ["mcp-remote", "http://localhost:3001/mcp?user=[user-id]"]
     }
   }
 }
@@ -121,6 +126,12 @@ Replace:
 
 - `http://localhost:3001` with your server's domain
 - `user-id` with the ID for the Connected User to use with ActionKit (this parameter only available in development mode)
+
+For production clients, send the Paragon User Token as an `Authorization: Bearer <token>` header on every MCP request.
+
+### Legacy SSE clients
+
+Existing clients can continue using `GET /sse` and `POST /messages` while `ENABLE_LEGACY_SSE` is `true`. To migrate, update the configured URL from `/sse` to `/mcp` and use a client that supports Streamable HTTP before disabling legacy SSE.
 
 ## Deploying the MCP Server
 The Paragon MCP server can be completely **self-hosted**. Deploy the MCP Server via Docker in any 
@@ -132,17 +143,20 @@ For testing, you can one-click deploy the server through Heroku.
 
 ## API Endpoints
 
-- `GET /sse`: Establishes SSE connection for MCP communication
-- `POST /messages`: Handles MCP message processing
+- `GET`, `POST`, and `DELETE /mcp`: Handles stateful Streamable HTTP communication
+- `GET /sse`: Establishes a deprecated legacy SSE connection when `ENABLE_LEGACY_SSE=true`
+- `POST /messages`: Handles deprecated legacy SSE messages when `ENABLE_LEGACY_SSE=true`
 - `GET /setup`: Handles integration setup flow
 
 ### Authorization
 
-The `GET /sse` endpoint (base URL for the MCP using the SSE transport) accepts an `Authorization` header with a Paragon User Token as the Bearer token.
+The `/mcp` endpoint accepts an `Authorization` header with a Paragon User Token as the Bearer token. Streamable HTTP clients must retain and send the same token used to initialize the session on every subsequent `GET`, `POST`, or `DELETE` request. If the token is rotated, initialize a new session. The legacy `GET /sse` endpoint also accepts this header when legacy SSE is enabled.
 
 The Paragon User Token is an RS256-encoded JWT that is verified using the public key stored by Paragon. Your MCP client (e.g. your application server or the service running your AI agent) will sign the User Token using the matching private key generated in the Paragon dashboard, which only your server has access to.
 
 This allows the MCP to validate the authenticity of the requesting user using the JWT signature and public key. Once authenticated, the MCP will associate the user ID encoded in the JWT with the active MCP session.
+
+Streamable HTTP sessions are stored in memory and expire after 30 minutes of inactivity by default. Clients must initialize a new session after expiration or a server restart. Deployments with multiple server instances must use session affinity so requests bearing the same `Mcp-Session-Id` reach the instance that created it.
 
 ## Adding Custom Actions with OpenAPI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.1",
-        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
         "ajv": "^8.17.1",
         "express": "^4.21.2",
@@ -435,6 +435,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -442,29 +454,50 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
-      "integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -474,47 +507,69 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -528,17 +583,19 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -569,9 +626,10 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -581,21 +639,47 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -604,6 +688,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -615,35 +700,44 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -653,30 +747,36 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -685,19 +785,68 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@openapi-contrib/openapi-schema-to-json-schema": {
@@ -908,6 +1057,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1463,9 +1629,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1473,7 +1644,24 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1742,6 +1930,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-to-json-parser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-to-json-parser/-/html-to-json-parser-2.0.1.tgz",
@@ -1767,14 +1964,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inflight": {
@@ -1792,6 +1994,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1837,7 +2048,8 @@
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -1862,6 +2074,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1879,6 +2100,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify": {
       "version": "1.2.1",
@@ -2396,15 +2623,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2452,6 +2709,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -2464,9 +2722,10 @@
       }
     },
     "node_modules/router/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2480,11 +2739,13 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -2609,13 +2870,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2627,12 +2889,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2956,14 +3219,6 @@
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^12.0.1",
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
     "ajv": "^8.17.1",
     "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "tsx --env-file=.env src/index.ts",
     "dev": "tsx watch --include \"./openapi/*\" --env-file=.env src/index.ts",
     "build": "node esbuild.config.js",
-    "start:prod": "node dist/index.mjs"
+    "start:prod": "node dist/index.mjs",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
+    "test": "node --import tsx --import ./test/setup.ts --test test/**/*.test.ts"
   },
   "engines": {
     "node": ">=22.14.0"

--- a/src/access-tokens.ts
+++ b/src/access-tokens.ts
@@ -3,23 +3,28 @@ import NodeCache from "node-cache";
 
 import { MINUTES } from "./utils";
 
-let accessTokensById: NodeCache;
+let accessTokensById: NodeCache | undefined;
 
 export function createAccessTokenStore() {
+  if (accessTokensById) {
+    return;
+  }
+
   accessTokensById = new NodeCache({
     stdTTL: MINUTES * 5,
   });
 }
 
 export function createAccessToken(token: string) {
+  createAccessTokenStore();
   const id = crypto.randomUUID();
-  accessTokensById.set(id, token);
+  accessTokensById!.set(id, token);
 
   return id;
 }
 
 export function getAccessTokenById(id: string) {
-  const result = accessTokensById.get<string | undefined>(id);
+  const result = accessTokensById?.get<string | undefined>(id);
 
   if (!result) {
     return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,106 +1,298 @@
-import express from "express";
+import { randomUUID } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+import express, { Request, Response } from "express";
 import jwt from "jsonwebtoken";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 
 import { createAccessTokenStore, getAccessTokenById } from "./access-tokens";
 import { registerTools } from "./tools";
-import { ExtendedTool, Integration, TransportPayload } from "./type";
+import { ExtendedTool, Integration } from "./type";
 import {
+  createProxyApiTool,
   envs,
+  getAllIntegrations,
+  getSigningKey,
   Logger,
   signJwt,
-  getSigningKey,
-  getAllIntegrations,
-  createProxyApiTool,
 } from "./utils";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { loadCustomOpenApiTools } from "./openapi";
 import { getCustomTools } from "./custom-tools";
 
-let transports: Record<string, TransportPayload> = {};
-const server = new Server({
-  name: "paragon-mcp",
-  version: "1.0.0",
-});
-let extraTools: Array<ExtendedTool> = [];
-let integrations: Array<Integration> = await getAllIntegrations(
-  signJwt({ userId: envs.PROJECT_ID })
-);
-if (envs.ENABLE_CUSTOM_OPENAPI_ACTIONS) {
-  extraTools = await loadCustomOpenApiTools(integrations);
-}
-if (envs.ENABLE_PROXY_API_TOOL) {
-  extraTools = extraTools.concat(
-    createProxyApiTool(
-      integrations.filter((i) => {
-        if (envs.LIMIT_TO_INTEGRATIONS) {
-          return envs.LIMIT_TO_INTEGRATIONS.includes(i.type);
-        }
-        return true;
-      })
-    )
-  );
-}
-if (envs.ENABLE_CUSTOM_TOOL) {
-  extraTools = extraTools.concat(getCustomTools());
-}
-registerTools({ server, extraTools, transports });
+type Session<TTransport> = {
+  transport: TTransport;
+  server: Server;
+  identity: string;
+};
 
-async function main() {
-  createAccessTokenStore();
+type RequestAuthentication = {
+  currentJwt: string;
+  identity: string;
+};
 
+type CreateAppOptions = {
+  extraTools?: Array<ExtendedTool>;
+  enableLegacySse?: boolean;
+  allowedHosts?: string[];
+  allowedOrigins?: string[];
+};
+
+function createMcpServer(
+  currentJwt: string,
+  extraTools: Array<ExtendedTool>
+): Server {
+  const server = new Server({
+    name: "paragon-mcp",
+    version: "1.0.0",
+  });
+  registerTools({ server, currentJwt, extraTools });
+  return server;
+}
+
+function authenticateRequest(
+  req: Request,
+  res: Response
+): RequestAuthentication | undefined {
+  const authorization = req.headers.authorization;
+  if (authorization?.startsWith("Bearer ")) {
+    const currentJwt = authorization.slice(7).trim();
+    if (currentJwt) {
+      return {
+        currentJwt,
+        identity: `bearer:${currentJwt}`,
+      };
+    }
+  }
+
+  if (envs.NODE_ENV === "development" && typeof req.query.user === "string") {
+    return {
+      currentJwt: signJwt({ userId: req.query.user }),
+      identity: `development:${req.query.user}`,
+    };
+  }
+
+  res.status(401).send("Unauthorized");
+  return undefined;
+}
+
+function getDefaultAllowedHosts(): string[] {
+  const allowedHosts = new Set(envs.MCP_ALLOWED_HOSTS);
+  try {
+    allowedHosts.add(new URL(envs.MCP_SERVER_URL).host);
+  } catch {
+    Logger.debug("MCP_SERVER_URL is not a valid URL; using explicit hosts only");
+  }
+
+  if (envs.NODE_ENV === "development") {
+    allowedHosts.add(`localhost:${envs.PORT}`);
+    allowedHosts.add(`127.0.0.1:${envs.PORT}`);
+  }
+
+  return [...allowedHosts];
+}
+
+function getDefaultAllowedOrigins(): string[] {
+  const allowedOrigins = new Set(envs.MCP_ALLOWED_ORIGINS);
+  try {
+    allowedOrigins.add(new URL(envs.MCP_SERVER_URL).origin);
+  } catch {
+    Logger.debug("MCP_SERVER_URL is not a valid URL; using explicit origins only");
+  }
+
+  if (envs.NODE_ENV === "development") {
+    allowedOrigins.add(`http://localhost:${envs.PORT}`);
+    allowedOrigins.add(`http://127.0.0.1:${envs.PORT}`);
+  }
+
+  return [...allowedOrigins];
+}
+
+function validateMcpRequest(
+  req: Request,
+  res: Response,
+  allowedHosts: string[],
+  allowedOrigins: string[]
+): boolean {
+  const host = req.headers.host;
+  if (!host || !allowedHosts.includes(host)) {
+    res.status(403).send("Forbidden");
+    return false;
+  }
+
+  const origin = req.headers.origin;
+  if (origin && !allowedOrigins.includes(origin)) {
+    res.status(403).send("Forbidden");
+    return false;
+  }
+
+  return true;
+}
+
+function sendJsonRpcError(
+  res: Response,
+  status: number,
+  code: number,
+  message: string
+): void {
+  res.status(status).json({
+    jsonrpc: "2.0",
+    error: { code, message },
+    id: null,
+  });
+}
+
+export function createApp({
+  extraTools = [],
+  enableLegacySse = envs.ENABLE_LEGACY_SSE,
+  allowedHosts = getDefaultAllowedHosts(),
+  allowedOrigins = getDefaultAllowedOrigins(),
+}: CreateAppOptions = {}) {
   const app = express();
+  const legacySessions = new Map<
+    string,
+    Session<SSEServerTransport>
+  >();
+  const streamableSessions = new Map<
+    string,
+    Session<StreamableHTTPServerTransport>
+  >();
 
+  app.use(express.json());
   app.use("/static", express.static("static"));
 
-  app.get("/sse", async (req, res) => {
-    let currentJwt = req.headers.authorization;
-
-    if (currentJwt && currentJwt.startsWith("Bearer ")) {
-      currentJwt = currentJwt.slice(7).trim();
-    } else if (envs.NODE_ENV === "development" && req.query.user) {
-      // In development, allow `user=` query parameter to be used
-      currentJwt = signJwt({ userId: req.query.user as string });
-    } else {
-      return res.status(401).send("Unauthorized");
+  app.all("/mcp", async (req, res) => {
+    if (!["GET", "POST", "DELETE"].includes(req.method)) {
+      res.set("Allow", "GET, POST, DELETE");
+      res.sendStatus(405);
+      return;
     }
 
-    const transport = new SSEServerTransport("/messages", res);
-    transports[transport.sessionId] = { transport, currentJwt };
+    if (!validateMcpRequest(req, res, allowedHosts, allowedOrigins)) {
+      return;
+    }
 
-    Logger.debug(
-      "Connected clients:",
-      Object.keys(transports).map((key) => ({
-        sessionId: key,
-        user: jwt.decode(transports[key].currentJwt)?.sub,
-      }))
-    );
+    const authentication = authenticateRequest(req, res);
+    if (!authentication) {
+      return;
+    }
 
-    res.on("close", () => {
-      Logger.debug("Client disconnected: ", transport.sessionId);
-      delete transports[transport.sessionId];
+    const sessionId = req.header("mcp-session-id");
+    let session: Session<StreamableHTTPServerTransport> | undefined;
+
+    if (sessionId) {
+      session = streamableSessions.get(sessionId);
+      if (!session) {
+        sendJsonRpcError(res, 404, -32001, "Session not found");
+        return;
+      }
+      if (session.identity !== authentication.identity) {
+        res.status(403).send("Forbidden");
+        return;
+      }
+    } else if (req.method === "POST" && isInitializeRequest(req.body)) {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: randomUUID,
+        onsessioninitialized: (initializedSessionId) => {
+          streamableSessions.set(initializedSessionId, session!);
+        },
+        onsessionclosed: (closedSessionId) => {
+          streamableSessions.delete(closedSessionId);
+        },
+      });
+      const server = createMcpServer(authentication.currentJwt, extraTools);
+      session = {
+        transport,
+        server,
+        identity: authentication.identity,
+      };
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          streamableSessions.delete(transport.sessionId);
+        }
+      };
+      await server.connect(transport);
+    } else {
+      sendJsonRpcError(
+        res,
+        400,
+        -32000,
+        "Mcp-Session-Id header is required"
+      );
+      return;
+    }
+
+    try {
+      await session.transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      if (!res.headersSent) {
+        sendJsonRpcError(res, 500, -32603, "Internal server error");
+      }
+      if (!session.transport.sessionId) {
+        await session.server.close();
+      }
+      Logger.debug("Error handling Streamable HTTP request:", error);
+    }
+  });
+
+  if (enableLegacySse) {
+    app.get("/sse", async (req, res) => {
+      const authentication = authenticateRequest(req, res);
+      if (!authentication) {
+        return;
+      }
+
+      const transport = new SSEServerTransport("/messages", res);
+      const server = createMcpServer(authentication.currentJwt, extraTools);
+      const session = {
+        transport,
+        server,
+        identity: authentication.identity,
+      };
+      legacySessions.set(transport.sessionId, session);
+      transport.onclose = () => {
+        legacySessions.delete(transport.sessionId);
+      };
+
+      Logger.debug(
+        "Connected legacy clients:",
+        [...legacySessions].map(([sessionId, payload]) => ({
+          sessionId,
+          user: jwt.decode(authentication.currentJwt)?.sub,
+          identity: payload.identity,
+        }))
+      );
+
+      await server.connect(transport);
     });
 
-    await server.connect(transport);
-  });
+    app.post("/messages", async (req, res) => {
+      const sessionId =
+        typeof req.query.sessionId === "string"
+          ? req.query.sessionId
+          : undefined;
+      const session = sessionId
+        ? legacySessions.get(sessionId)
+        : undefined;
 
-  app.post("/messages", async (req, res) => {
-    const sessionId = req.query.sessionId as string;
-    const transportPayload = transports[sessionId];
+      if (!session) {
+        res.status(404).json({ error: "No transport found for sessionId" });
+        return;
+      }
 
-    if (sessionId && transportPayload) {
       try {
-        return await transportPayload.transport.handlePostMessage(req, res);
-      } catch (err) {
+        await session.transport.handlePostMessage(req, res, req.body);
+      } catch (error) {
         if (!res.headersSent) {
-          return res.status(500).send(err instanceof Error ? err.message : err);
+          res
+            .status(500)
+            .send(error instanceof Error ? error.message : String(error));
         }
       }
-    }
-
-    console.error("No transport found for sessionId", sessionId);
-    return res.status(404).json({ error: "No transport found for sessionId" });
-  });
+    });
+  }
 
   app.get("/setup", async (req, res) => {
     const tokenId = req.query.token;
@@ -146,25 +338,83 @@ async function main() {
     `);
   });
 
-  app.listen(Number(envs.PORT));
-  console.log(`Server is running on`, `http://localhost:${envs.PORT}`);
+  const closeSessions = async () => {
+    await Promise.all([
+      ...[...legacySessions.values()].map(({ server }) => server.close()),
+      ...[...streamableSessions.values()].map(({ server }) => server.close()),
+    ]);
+    legacySessions.clear();
+    streamableSessions.clear();
+  };
+
+  return {
+    app,
+    closeSessions,
+    getSessionCounts: () => ({
+      legacy: legacySessions.size,
+      streamable: streamableSessions.size,
+    }),
+  };
 }
 
-const handleShutdown = async () => {
-  console.log("Closing all transports...");
-  await Promise.all(
-    Object.values(transports).map(async (transport) => {
-      await transport.transport.close();
-    })
-  );
-  await server.close();
-  for (const key in transports) {
-    delete transports[key];
+async function loadExtraTools(): Promise<Array<ExtendedTool>> {
+  let extraTools: Array<ExtendedTool> = [];
+  const integrations: Array<Integration> =
+    (await getAllIntegrations(signJwt({ userId: envs.PROJECT_ID }))) ?? [];
+
+  if (envs.ENABLE_CUSTOM_OPENAPI_ACTIONS) {
+    extraTools = await loadCustomOpenApiTools(integrations);
   }
-  process.exit(0);
-};
+  if (envs.ENABLE_PROXY_API_TOOL) {
+    extraTools = extraTools.concat(
+      createProxyApiTool(
+        integrations.filter((integration) => {
+          if (envs.LIMIT_TO_INTEGRATIONS) {
+            return envs.LIMIT_TO_INTEGRATIONS.includes(integration.type);
+          }
+          return true;
+        })
+      )
+    );
+  }
+  if (envs.ENABLE_CUSTOM_TOOL) {
+    extraTools = extraTools.concat(getCustomTools());
+  }
 
-process.on("SIGTERM", handleShutdown);
-process.on("SIGINT", handleShutdown);
+  return extraTools;
+}
 
-main();
+async function main() {
+  createAccessTokenStore();
+  const { app, closeSessions } = createApp({
+    extraTools: await loadExtraTools(),
+  });
+  const httpServer = app.listen(Number(envs.PORT), () => {
+    console.log(`Server is running on http://localhost:${envs.PORT}`);
+  });
+
+  const handleShutdown = async () => {
+    console.log("Closing all transports...");
+    await closeSessions();
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", handleShutdown);
+  process.on("SIGINT", handleShutdown);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import {
 import { loadCustomOpenApiTools } from "./openapi";
 import { getCustomTools } from "./custom-tools";
 
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
 type Session<TTransport> = {
   transport: TTransport;
   server: Server;
@@ -238,9 +240,11 @@ export function createApp({
     const session = streamableSessions.get(sessionId);
     if (session?.authenticationTimeout) {
       clearTimeout(session.authenticationTimeout);
+      session.authenticationTimeout = undefined;
     }
     if (session?.idleTimeout) {
       clearTimeout(session.idleTimeout);
+      session.idleTimeout = undefined;
     }
     streamableSessions.delete(sessionId);
   };
@@ -266,10 +270,22 @@ export function createApp({
     if (expiresAt === undefined) {
       return;
     }
-    session.authenticationTimeout = setTimeout(() => {
+
+    const remainingMs = expiresAt - Date.now();
+    if (remainingMs <= 0) {
       expireStreamableSession(sessionId, session);
-    }, Math.max(0, expiresAt - Date.now()));
-    session.authenticationTimeout.unref();
+      return;
+    }
+
+    const authenticationTimeout = setTimeout(() => {
+      if (session.authenticationTimeout !== authenticationTimeout) {
+        return;
+      }
+      session.authenticationTimeout = undefined;
+      scheduleStreamableSessionAuthenticationExpiry(sessionId, session);
+    }, Math.min(remainingMs, MAX_TIMEOUT_MS));
+    session.authenticationTimeout = authenticationTimeout;
+    authenticationTimeout.unref();
   };
 
   const scheduleStreamableSessionExpiry = (
@@ -279,10 +295,16 @@ export function createApp({
     if (session.idleTimeout) {
       clearTimeout(session.idleTimeout);
     }
-    session.idleTimeout = setTimeout(() => {
+
+    const idleTimeout = setTimeout(() => {
+      if (session.idleTimeout !== idleTimeout || session.activeRequests > 0) {
+        return;
+      }
+      session.idleTimeout = undefined;
       expireStreamableSession(sessionId, session);
     }, sessionIdleTimeoutMs);
-    session.idleTimeout.unref();
+    session.idleTimeout = idleTimeout;
+    idleTimeout.unref();
   };
 
   app.use("/static", express.static("static"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,10 +253,7 @@ export function createApp({
   };
 
   app.use("/static", express.static("static"));
-  app.use("/mcp", express.json({ limit: "4mb" }));
-  app.use("/mcp", handleMcpJsonError);
-
-  app.all("/mcp", async (req, res) => {
+  app.use("/mcp", (req, res, next) => {
     if (!["GET", "POST", "DELETE"].includes(req.method)) {
       res.set("Allow", "GET, POST, DELETE");
       res.sendStatus(405);
@@ -271,6 +268,15 @@ export function createApp({
     if (!authentication) {
       return;
     }
+
+    res.locals.authentication = authentication;
+    next();
+  });
+  app.use("/mcp", express.json({ limit: "4mb" }));
+  app.use("/mcp", handleMcpJsonError);
+
+  app.all("/mcp", async (req, res) => {
+    const authentication = res.locals.authentication as RequestAuthentication;
 
     if (req.method === "POST" && !req.is("application/json")) {
       sendJsonRpcError(
@@ -333,7 +339,7 @@ export function createApp({
         reservationReleased = true;
         pendingStreamableSessions -= 1;
       };
-      transport.onclose = () => {
+      server.onclose = () => {
         if (transport.sessionId) {
           deleteStreamableSession(transport.sessionId);
         }
@@ -419,7 +425,26 @@ export function createApp({
         })),
       );
 
-      await server.connect(transport);
+      try {
+        await server.connect(transport);
+      } catch (error) {
+        Logger.debug("Error connecting legacy SSE transport:", error);
+        legacySessions.delete(transport.sessionId);
+        if (!res.headersSent) {
+          res.status(500);
+        }
+        try {
+          await server.close();
+        } catch (closeError) {
+          Logger.debug(
+            "Error closing failed legacy SSE transport:",
+            closeError,
+          );
+        }
+        if (!res.writableEnded) {
+          res.end();
+        }
+      }
     });
 
     app.post("/messages", async (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,15 @@ type Session<TTransport> = {
 
 type StreamableSession = Session<StreamableHTTPServerTransport> & {
   activeRequests: number;
+  authenticationTimeout?: ReturnType<typeof setTimeout>;
   idleTimeout?: ReturnType<typeof setTimeout>;
 };
 
 type RequestAuthentication = {
   currentJwt: string;
+  expiresAt?: number;
   identity: string;
+  principalIdentity: string;
 };
 
 type CreateAppOptions = {
@@ -83,8 +86,13 @@ function authenticateRequest(
         if (typeof payload !== "string" && typeof payload.sub === "string") {
           return {
             currentJwt,
+            expiresAt:
+              typeof payload.exp === "number" ? payload.exp * 1000 : undefined,
             identity: `bearer:${createHash("sha256")
               .update(currentJwt)
+              .digest("hex")}`,
+            principalIdentity: `bearer-subject:${createHash("sha256")
+              .update(payload.sub)
               .digest("hex")}`,
           };
         }
@@ -102,6 +110,7 @@ function authenticateRequest(
     return {
       currentJwt: signJwt({ userId: req.query.user }),
       identity: `development:${req.query.user}`,
+      principalIdentity: `development:${req.query.user}`,
     };
   }
 
@@ -227,10 +236,40 @@ export function createApp({
 
   const deleteStreamableSession = (sessionId: string) => {
     const session = streamableSessions.get(sessionId);
+    if (session?.authenticationTimeout) {
+      clearTimeout(session.authenticationTimeout);
+    }
     if (session?.idleTimeout) {
       clearTimeout(session.idleTimeout);
     }
     streamableSessions.delete(sessionId);
+  };
+
+  const expireStreamableSession = (
+    sessionId: string,
+    session: StreamableSession,
+  ) => {
+    if (streamableSessions.get(sessionId) !== session) {
+      return;
+    }
+    deleteStreamableSession(sessionId);
+    void session.server.close().catch((error) => {
+      Logger.debug("Error closing expired Streamable HTTP session:", error);
+    });
+  };
+
+  const scheduleStreamableSessionAuthenticationExpiry = (
+    sessionId: string,
+    session: StreamableSession,
+  ) => {
+    const expiresAt = session.authentication.expiresAt;
+    if (expiresAt === undefined) {
+      return;
+    }
+    session.authenticationTimeout = setTimeout(() => {
+      expireStreamableSession(sessionId, session);
+    }, Math.max(0, expiresAt - Date.now()));
+    session.authenticationTimeout.unref();
   };
 
   const scheduleStreamableSessionExpiry = (
@@ -241,13 +280,7 @@ export function createApp({
       clearTimeout(session.idleTimeout);
     }
     session.idleTimeout = setTimeout(() => {
-      if (streamableSessions.get(sessionId) !== session) {
-        return;
-      }
-      streamableSessions.delete(sessionId);
-      void session.server.close().catch((error) => {
-        Logger.debug("Error closing expired Streamable HTTP session:", error);
-      });
+      expireStreamableSession(sessionId, session);
     }, sessionIdleTimeoutMs);
     session.idleTimeout.unref();
   };
@@ -300,7 +333,13 @@ export function createApp({
         sendJsonRpcError(res, 404, -32001, "Session not found");
         return;
       }
-      if (session.authentication.identity !== authentication.identity) {
+      const matchesSessionToken =
+        session.authentication.identity === authentication.identity;
+      const terminatesOwnedSession =
+        req.method === "DELETE" &&
+        session.authentication.principalIdentity ===
+          authentication.principalIdentity;
+      if (!matchesSessionToken && !terminatesOwnedSession) {
         res.status(403).send("Forbidden");
         return;
       }
@@ -317,6 +356,10 @@ export function createApp({
         sessionIdGenerator: randomUUID,
         onsessioninitialized: (initializedSessionId) => {
           streamableSessions.set(initializedSessionId, session!);
+          scheduleStreamableSessionAuthenticationExpiry(
+            initializedSessionId,
+            session!,
+          );
           releaseStreamableSessionReservation?.();
         },
         onsessionclosed: (closedSessionId) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ type CreateAppOptions = {
 
 function createMcpServer(
   authentication: RequestAuthentication,
-  extraTools: Array<ExtendedTool>
+  extraTools: Array<ExtendedTool>,
 ): Server {
   const server = new Server({
     name: "paragon-mcp",
@@ -65,7 +65,7 @@ function createMcpServer(
 
 function authenticateRequest(
   req: Request,
-  res: Response
+  res: Response,
 ): RequestAuthentication | undefined {
   const authorization = req.headers.authorization;
   if (authorization) {
@@ -114,7 +114,9 @@ function getDefaultAllowedHosts(): string[] {
   try {
     allowedHosts.add(new URL(envs.MCP_SERVER_URL).host);
   } catch {
-    Logger.debug("MCP_SERVER_URL is not a valid URL; using explicit hosts only");
+    Logger.debug(
+      "MCP_SERVER_URL is not a valid URL; using explicit hosts only",
+    );
   }
 
   allowedHosts.add(`localhost:${envs.PORT}`);
@@ -128,7 +130,9 @@ function getDefaultAllowedOrigins(): string[] {
   try {
     allowedOrigins.add(new URL(envs.MCP_SERVER_URL).origin);
   } catch {
-    Logger.debug("MCP_SERVER_URL is not a valid URL; using explicit origins only");
+    Logger.debug(
+      "MCP_SERVER_URL is not a valid URL; using explicit origins only",
+    );
   }
 
   if (envs.NODE_ENV === "development") {
@@ -143,7 +147,7 @@ function validateMcpRequest(
   req: Request,
   res: Response,
   allowedHosts: string[],
-  allowedOrigins: string[]
+  allowedOrigins: string[],
 ): boolean {
   const host = req.headers.host;
   if (!host || !allowedHosts.includes(host)) {
@@ -164,7 +168,7 @@ function sendJsonRpcError(
   res: Response,
   status: number,
   code: number,
-  message: string
+  message: string,
 ): void {
   res.status(status).json({
     jsonrpc: "2.0",
@@ -177,7 +181,7 @@ function handleMcpJsonError(
   error: unknown,
   _req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): void {
   if (error instanceof SyntaxError) {
     sendJsonRpcError(res, 400, -32700, "Parse error");
@@ -217,11 +221,9 @@ export function createApp({
 }: CreateAppOptions = {}) {
   createAccessTokenStore();
   const app = express();
-  const legacySessions = new Map<
-    string,
-    Session<SSEServerTransport>
-  >();
+  const legacySessions = new Map<string, Session<SSEServerTransport>>();
   const streamableSessions = new Map<string, StreamableSession>();
+  let pendingStreamableSessions = 0;
 
   const deleteStreamableSession = (sessionId: string) => {
     const session = streamableSessions.get(sessionId);
@@ -233,7 +235,7 @@ export function createApp({
 
   const scheduleStreamableSessionExpiry = (
     sessionId: string,
-    session: StreamableSession
+    session: StreamableSession,
   ) => {
     if (session.idleTimeout) {
       clearTimeout(session.idleTimeout);
@@ -275,7 +277,7 @@ export function createApp({
         res,
         415,
         -32000,
-        "Unsupported Media Type: Content-Type must be application/json"
+        "Unsupported Media Type: Content-Type must be application/json",
       );
       return;
     }
@@ -284,6 +286,7 @@ export function createApp({
     const isInitializationRequest =
       !sessionId && req.method === "POST" && isInitializeRequest(req.body);
     let session: StreamableSession | undefined;
+    let releaseStreamableSessionReservation: (() => void) | undefined;
 
     if (sessionId) {
       session = streamableSessions.get(sessionId);
@@ -296,7 +299,10 @@ export function createApp({
         return;
       }
     } else if (isInitializationRequest) {
-      if (streamableSessions.size >= maxStreamableSessions) {
+      if (
+        streamableSessions.size + pendingStreamableSessions >=
+        maxStreamableSessions
+      ) {
         sendJsonRpcError(res, 503, -32000, "Session capacity reached");
         return;
       }
@@ -305,6 +311,7 @@ export function createApp({
         sessionIdGenerator: randomUUID,
         onsessioninitialized: (initializedSessionId) => {
           streamableSessions.set(initializedSessionId, session!);
+          releaseStreamableSessionReservation?.();
         },
         onsessionclosed: (closedSessionId) => {
           deleteStreamableSession(closedSessionId);
@@ -317,6 +324,15 @@ export function createApp({
         authentication,
         activeRequests: 0,
       };
+      pendingStreamableSessions += 1;
+      let reservationReleased = false;
+      releaseStreamableSessionReservation = () => {
+        if (reservationReleased) {
+          return;
+        }
+        reservationReleased = true;
+        pendingStreamableSessions -= 1;
+      };
       transport.onclose = () => {
         if (transport.sessionId) {
           deleteStreamableSession(transport.sessionId);
@@ -326,16 +342,20 @@ export function createApp({
         await server.connect(transport);
       } catch (error) {
         Logger.debug("Error connecting Streamable HTTP transport:", error);
+        releaseStreamableSessionReservation();
+        try {
+          await server.close();
+        } catch (closeError) {
+          Logger.debug(
+            "Error closing failed Streamable HTTP transport:",
+            closeError,
+          );
+        }
         sendJsonRpcError(res, 500, -32603, "Internal server error");
         return;
       }
     } else {
-      sendJsonRpcError(
-        res,
-        400,
-        -32000,
-        "Mcp-Session-Id header is required"
-      );
+      sendJsonRpcError(res, 400, -32000, "Mcp-Session-Id header is required");
       return;
     }
 
@@ -359,6 +379,7 @@ export function createApp({
       }
       Logger.debug("Error handling Streamable HTTP request:", error);
     } finally {
+      releaseStreamableSessionReservation?.();
       session.activeRequests -= 1;
       const initializedSessionId = session.transport.sessionId;
       if (
@@ -386,7 +407,7 @@ export function createApp({
         authentication,
       };
       legacySessions.set(transport.sessionId, session);
-      transport.onclose = () => {
+      server.onclose = () => {
         legacySessions.delete(transport.sessionId);
       };
 
@@ -395,7 +416,7 @@ export function createApp({
         [...legacySessions].map(([sessionId, payload]) => ({
           sessionId,
           user: jwt.decode(payload.authentication.currentJwt)?.sub,
-        }))
+        })),
       );
 
       await server.connect(transport);
@@ -406,9 +427,7 @@ export function createApp({
         typeof req.query.sessionId === "string"
           ? req.query.sessionId
           : undefined;
-      const session = sessionId
-        ? legacySessions.get(sessionId)
-        : undefined;
+      const session = sessionId ? legacySessions.get(sessionId) : undefined;
 
       if (!session) {
         res.status(404).json({ error: "No transport found for sessionId" });
@@ -461,7 +480,7 @@ export function createApp({
         <head>
           <script src="${envs.CONNECT_SDK_CDN_URL}"></script>
           <script id="token-info" type="application/json">${JSON.stringify(
-            tokenInfo
+            tokenInfo,
           )}</script>
           <script type="text/javascript" src="/static/js/index.js"></script>
         </head>
@@ -473,7 +492,7 @@ export function createApp({
 
   const closeSessions = async () => {
     const streamableServers = [...streamableSessions.values()].map(
-      ({ server }) => server
+      ({ server }) => server,
     );
     for (const sessionId of streamableSessions.keys()) {
       deleteStreamableSession(sessionId);
@@ -511,8 +530,8 @@ async function loadExtraTools(): Promise<Array<ExtendedTool>> {
             return envs.LIMIT_TO_INTEGRATIONS.includes(integration.type);
           }
           return true;
-        })
-      )
+        }),
+      ),
     );
   }
   if (envs.ENABLE_CUSTOM_TOOL) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
-import express, { Request, Response } from "express";
+import express, { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
@@ -25,7 +25,12 @@ import { getCustomTools } from "./custom-tools";
 type Session<TTransport> = {
   transport: TTransport;
   server: Server;
-  identity: string;
+  authentication: RequestAuthentication;
+};
+
+type StreamableSession = Session<StreamableHTTPServerTransport> & {
+  activeRequests: number;
+  idleTimeout?: ReturnType<typeof setTimeout>;
 };
 
 type RequestAuthentication = {
@@ -38,17 +43,23 @@ type CreateAppOptions = {
   enableLegacySse?: boolean;
   allowedHosts?: string[];
   allowedOrigins?: string[];
+  sessionIdleTimeoutMs?: number;
+  maxStreamableSessions?: number;
 };
 
 function createMcpServer(
-  currentJwt: string,
+  authentication: RequestAuthentication,
   extraTools: Array<ExtendedTool>
 ): Server {
   const server = new Server({
     name: "paragon-mcp",
     version: "1.0.0",
   });
-  registerTools({ server, currentJwt, extraTools });
+  registerTools({
+    server,
+    getCurrentJwt: () => authentication.currentJwt,
+    extraTools,
+  });
   return server;
 }
 
@@ -57,14 +68,34 @@ function authenticateRequest(
   res: Response
 ): RequestAuthentication | undefined {
   const authorization = req.headers.authorization;
-  if (authorization?.startsWith("Bearer ")) {
+  if (authorization) {
+    if (!authorization.startsWith("Bearer ")) {
+      res.status(401).send("Unauthorized");
+      return undefined;
+    }
+
     const currentJwt = authorization.slice(7).trim();
     if (currentJwt) {
-      return {
-        currentJwt,
-        identity: `bearer:${currentJwt}`,
-      };
+      try {
+        const payload = jwt.verify(currentJwt, getSigningKey(), {
+          algorithms: ["RS256"],
+        });
+        if (typeof payload !== "string" && typeof payload.sub === "string") {
+          return {
+            currentJwt,
+            identity: `bearer:${createHash("sha256")
+              .update(currentJwt)
+              .digest("hex")}`,
+          };
+        }
+      } catch {
+        res.status(401).send("Unauthorized");
+        return undefined;
+      }
     }
+
+    res.status(401).send("Unauthorized");
+    return undefined;
   }
 
   if (envs.NODE_ENV === "development" && typeof req.query.user === "string") {
@@ -86,10 +117,8 @@ function getDefaultAllowedHosts(): string[] {
     Logger.debug("MCP_SERVER_URL is not a valid URL; using explicit hosts only");
   }
 
-  if (envs.NODE_ENV === "development") {
-    allowedHosts.add(`localhost:${envs.PORT}`);
-    allowedHosts.add(`127.0.0.1:${envs.PORT}`);
-  }
+  allowedHosts.add(`localhost:${envs.PORT}`);
+  allowedHosts.add(`127.0.0.1:${envs.PORT}`);
 
   return [...allowedHosts];
 }
@@ -144,24 +173,86 @@ function sendJsonRpcError(
   });
 }
 
+function handleMcpJsonError(
+  error: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (error instanceof SyntaxError) {
+    sendJsonRpcError(res, 400, -32700, "Parse error");
+    return;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    error.status === 415
+  ) {
+    sendJsonRpcError(res, 415, -32000, "Unsupported Media Type");
+    return;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    error.status === 413
+  ) {
+    sendJsonRpcError(res, 413, -32000, "Request body too large");
+    return;
+  }
+
+  next(error);
+}
+
 export function createApp({
   extraTools = [],
   enableLegacySse = envs.ENABLE_LEGACY_SSE,
   allowedHosts = getDefaultAllowedHosts(),
   allowedOrigins = getDefaultAllowedOrigins(),
+  sessionIdleTimeoutMs = envs.MCP_SESSION_IDLE_TIMEOUT_MS,
+  maxStreamableSessions = envs.MCP_MAX_SESSIONS,
 }: CreateAppOptions = {}) {
+  createAccessTokenStore();
   const app = express();
   const legacySessions = new Map<
     string,
     Session<SSEServerTransport>
   >();
-  const streamableSessions = new Map<
-    string,
-    Session<StreamableHTTPServerTransport>
-  >();
+  const streamableSessions = new Map<string, StreamableSession>();
 
-  app.use(express.json());
+  const deleteStreamableSession = (sessionId: string) => {
+    const session = streamableSessions.get(sessionId);
+    if (session?.idleTimeout) {
+      clearTimeout(session.idleTimeout);
+    }
+    streamableSessions.delete(sessionId);
+  };
+
+  const scheduleStreamableSessionExpiry = (
+    sessionId: string,
+    session: StreamableSession
+  ) => {
+    if (session.idleTimeout) {
+      clearTimeout(session.idleTimeout);
+    }
+    session.idleTimeout = setTimeout(() => {
+      if (streamableSessions.get(sessionId) !== session) {
+        return;
+      }
+      streamableSessions.delete(sessionId);
+      void session.server.close().catch((error) => {
+        Logger.debug("Error closing expired Streamable HTTP session:", error);
+      });
+    }, sessionIdleTimeoutMs);
+    session.idleTimeout.unref();
+  };
+
   app.use("/static", express.static("static"));
+  app.use("/mcp", express.json({ limit: "4mb" }));
+  app.use("/mcp", handleMcpJsonError);
 
   app.all("/mcp", async (req, res) => {
     if (!["GET", "POST", "DELETE"].includes(req.method)) {
@@ -179,8 +270,20 @@ export function createApp({
       return;
     }
 
+    if (req.method === "POST" && !req.is("application/json")) {
+      sendJsonRpcError(
+        res,
+        415,
+        -32000,
+        "Unsupported Media Type: Content-Type must be application/json"
+      );
+      return;
+    }
+
     const sessionId = req.header("mcp-session-id");
-    let session: Session<StreamableHTTPServerTransport> | undefined;
+    const isInitializationRequest =
+      !sessionId && req.method === "POST" && isInitializeRequest(req.body);
+    let session: StreamableSession | undefined;
 
     if (sessionId) {
       session = streamableSessions.get(sessionId);
@@ -188,32 +291,44 @@ export function createApp({
         sendJsonRpcError(res, 404, -32001, "Session not found");
         return;
       }
-      if (session.identity !== authentication.identity) {
+      if (session.authentication.identity !== authentication.identity) {
         res.status(403).send("Forbidden");
         return;
       }
-    } else if (req.method === "POST" && isInitializeRequest(req.body)) {
+    } else if (isInitializationRequest) {
+      if (streamableSessions.size >= maxStreamableSessions) {
+        sendJsonRpcError(res, 503, -32000, "Session capacity reached");
+        return;
+      }
+
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: randomUUID,
         onsessioninitialized: (initializedSessionId) => {
           streamableSessions.set(initializedSessionId, session!);
         },
         onsessionclosed: (closedSessionId) => {
-          streamableSessions.delete(closedSessionId);
+          deleteStreamableSession(closedSessionId);
         },
       });
-      const server = createMcpServer(authentication.currentJwt, extraTools);
+      const server = createMcpServer(authentication, extraTools);
       session = {
         transport,
         server,
-        identity: authentication.identity,
+        authentication,
+        activeRequests: 0,
       };
       transport.onclose = () => {
         if (transport.sessionId) {
-          streamableSessions.delete(transport.sessionId);
+          deleteStreamableSession(transport.sessionId);
         }
       };
-      await server.connect(transport);
+      try {
+        await server.connect(transport);
+      } catch (error) {
+        Logger.debug("Error connecting Streamable HTTP transport:", error);
+        sendJsonRpcError(res, 500, -32603, "Internal server error");
+        return;
+      }
     } else {
       sendJsonRpcError(
         res,
@@ -224,8 +339,17 @@ export function createApp({
       return;
     }
 
+    if (session.idleTimeout) {
+      clearTimeout(session.idleTimeout);
+      session.idleTimeout = undefined;
+    }
+    session.activeRequests += 1;
+
     try {
       await session.transport.handleRequest(req, res, req.body);
+      if (isInitializationRequest && !session.transport.sessionId) {
+        await session.server.close();
+      }
     } catch (error) {
       if (!res.headersSent) {
         sendJsonRpcError(res, 500, -32603, "Internal server error");
@@ -234,6 +358,16 @@ export function createApp({
         await session.server.close();
       }
       Logger.debug("Error handling Streamable HTTP request:", error);
+    } finally {
+      session.activeRequests -= 1;
+      const initializedSessionId = session.transport.sessionId;
+      if (
+        initializedSessionId &&
+        streamableSessions.get(initializedSessionId) === session &&
+        session.activeRequests === 0
+      ) {
+        scheduleStreamableSessionExpiry(initializedSessionId, session);
+      }
     }
   });
 
@@ -245,11 +379,11 @@ export function createApp({
       }
 
       const transport = new SSEServerTransport("/messages", res);
-      const server = createMcpServer(authentication.currentJwt, extraTools);
+      const server = createMcpServer(authentication, extraTools);
       const session = {
         transport,
         server,
-        identity: authentication.identity,
+        authentication,
       };
       legacySessions.set(transport.sessionId, session);
       transport.onclose = () => {
@@ -260,8 +394,7 @@ export function createApp({
         "Connected legacy clients:",
         [...legacySessions].map(([sessionId, payload]) => ({
           sessionId,
-          user: jwt.decode(authentication.currentJwt)?.sub,
-          identity: payload.identity,
+          user: jwt.decode(payload.authentication.currentJwt)?.sub,
         }))
       );
 
@@ -283,7 +416,7 @@ export function createApp({
       }
 
       try {
-        await session.transport.handlePostMessage(req, res, req.body);
+        await session.transport.handlePostMessage(req, res);
       } catch (error) {
         if (!res.headersSent) {
           res
@@ -339,12 +472,17 @@ export function createApp({
   });
 
   const closeSessions = async () => {
+    const streamableServers = [...streamableSessions.values()].map(
+      ({ server }) => server
+    );
+    for (const sessionId of streamableSessions.keys()) {
+      deleteStreamableSession(sessionId);
+    }
     await Promise.all([
       ...[...legacySessions.values()].map(({ server }) => server.close()),
-      ...[...streamableSessions.values()].map(({ server }) => server.close()),
+      ...streamableServers.map((server) => server.close()),
     ]);
     legacySessions.clear();
-    streamableSessions.clear();
   };
 
   return {
@@ -385,7 +523,6 @@ async function loadExtraTools(): Promise<Array<ExtendedTool>> {
 }
 
 async function main() {
-  createAccessTokenStore();
   const { app, closeSessions } = createApp({
     extraTools: await loadExtraTools(),
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,15 +296,26 @@ export function createApp({
       clearTimeout(session.idleTimeout);
     }
 
-    const idleTimeout = setTimeout(() => {
-      if (session.idleTimeout !== idleTimeout || session.activeRequests > 0) {
+    const expiresAt = Date.now() + sessionIdleTimeoutMs;
+    const scheduleIdleTimeout = () => {
+      const remainingMs = expiresAt - Date.now();
+      if (remainingMs <= 0) {
+        expireStreamableSession(sessionId, session);
         return;
       }
-      session.idleTimeout = undefined;
-      expireStreamableSession(sessionId, session);
-    }, sessionIdleTimeoutMs);
-    session.idleTimeout = idleTimeout;
-    idleTimeout.unref();
+
+      const idleTimeout = setTimeout(() => {
+        if (session.idleTimeout !== idleTimeout || session.activeRequests > 0) {
+          return;
+        }
+        session.idleTimeout = undefined;
+        scheduleIdleTimeout();
+      }, Math.min(remainingMs, MAX_TIMEOUT_MS));
+      session.idleTimeout = idleTimeout;
+      idleTimeout.unref();
+    };
+
+    scheduleIdleTimeout();
   };
 
   app.use("/static", express.static("static"));

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,7 +9,6 @@ import { JsonResponseError, UserNotConnectedError } from "./errors";
 import {
   ExtendedTool,
   ProxyApiRequestToolArgs,
-  TransportPayload,
 } from "./type";
 import {
   decodeJwt,
@@ -50,13 +49,15 @@ async function getAndProcessTools(
 
 export function registerTools({
   server,
+  currentJwt,
   extraTools = [],
-  transports,
 }: {
   server: Server;
+  currentJwt: string;
   extraTools?: Array<ExtendedTool>;
-  transports: Record<string, TransportPayload>;
 }) {
+  let cachedTools: Array<ExtendedTool> | undefined;
+
   server.registerCapabilities({
     tools: {
       listChanged: true,
@@ -65,35 +66,24 @@ export function registerTools({
 
   server.setRequestHandler(
     ListToolsRequestSchema,
-    async (_params, { sessionId }) => {
-      if (!sessionId || !transports[sessionId]) {
-        throw new Error(`No session found by ID: ${sessionId}`);
-      }
-      const sessionData = transports[sessionId];
-
-      if (sessionData.cachedTools) {
-        return { tools: sessionData.cachedTools };
+    async () => {
+      if (cachedTools) {
+        return { tools: cachedTools };
       }
 
-      const filteredTools = await getAndProcessTools(sessionData.currentJwt, extraTools);
-      transports[sessionId].cachedTools = filteredTools;
-      return { tools: filteredTools };
+      cachedTools = await getAndProcessTools(currentJwt, extraTools);
+      return { tools: cachedTools };
     }
   );
 
   server.setRequestHandler(
     CallToolRequestSchema,
-    async (request, { sessionId }) => {
-      if (!sessionId || !transports[sessionId]) {
-        throw new Error(`No session found by ID: ${sessionId}`);
-      }
+    async (request) => {
       const { name, arguments: args } = request.params;
-      const sessionData = transports[sessionId];
-      if (!sessionData.cachedTools) {
-        sessionData.cachedTools = await getAndProcessTools(sessionData.currentJwt, extraTools);
+      if (!cachedTools) {
+        cachedTools = await getAndProcessTools(currentJwt, extraTools);
       }
-      const dynamicTools = sessionData.cachedTools;
-      const tool = dynamicTools.find((t) => t.name === name);
+      const tool = cachedTools.find((candidate) => candidate.name === name);
       if (!tool) {
         throw new Error(`Tool not found: ${name}`);
       }
@@ -122,24 +112,24 @@ export function registerTools({
           response = await performOpenApiAction(
             tool,
             args as { params: any; body: any },
-            transports[sessionId].currentJwt
+            currentJwt
           );
         } else if (tool.name === "CALL_API_REQUEST") {
           response = await performProxyApiRequest(
             args as ProxyApiRequestToolArgs,
-            transports[sessionId].currentJwt
+            currentJwt
           );
         } else if (tool.name.split("_")[0] === "CUSTOM") {
           response = await performCustomAction(
             tool.name,
             args,
-            transports[sessionId].currentJwt
+            currentJwt
           );
         } else {
           response = await performAction(
             tool.name,
             args,
-            transports[sessionId].currentJwt
+            currentJwt
           );
         }
 
@@ -164,8 +154,7 @@ export function registerTools({
         if (error instanceof UserNotConnectedError) {
           let setupUrl;
           try {
-            let userId = decodeJwt(transports[sessionId!].currentJwt)?.payload
-              .sub as string;
+            let userId = decodeJwt(currentJwt)?.payload.sub as string;
             if (!userId) {
               throw new Error("User ID not found");
             }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -49,11 +49,11 @@ async function getAndProcessTools(
 
 export function registerTools({
   server,
-  currentJwt,
+  getCurrentJwt,
   extraTools = [],
 }: {
   server: Server;
-  currentJwt: string;
+  getCurrentJwt: () => string;
   extraTools?: Array<ExtendedTool>;
 }) {
   let cachedTools: Array<ExtendedTool> | undefined;
@@ -71,7 +71,7 @@ export function registerTools({
         return { tools: cachedTools };
       }
 
-      cachedTools = await getAndProcessTools(currentJwt, extraTools);
+      cachedTools = await getAndProcessTools(getCurrentJwt(), extraTools);
       return { tools: cachedTools };
     }
   );
@@ -81,7 +81,7 @@ export function registerTools({
     async (request) => {
       const { name, arguments: args } = request.params;
       if (!cachedTools) {
-        cachedTools = await getAndProcessTools(currentJwt, extraTools);
+        cachedTools = await getAndProcessTools(getCurrentJwt(), extraTools);
       }
       const tool = cachedTools.find((candidate) => candidate.name === name);
       if (!tool) {
@@ -89,6 +89,7 @@ export function registerTools({
       }
 
       try {
+        const currentJwt = getCurrentJwt();
         const validate = ajv.compile(tool.inputSchema);
         const valid = validate(args);
 
@@ -154,7 +155,7 @@ export function registerTools({
         if (error instanceof UserNotConnectedError) {
           let setupUrl;
           try {
-            let userId = decodeJwt(currentJwt)?.payload.sub as string;
+            let userId = decodeJwt(getCurrentJwt())?.payload.sub as string;
             if (!userId) {
               throw new Error("User ID not found");
             }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,3 @@
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 export interface LinkConnectionProps {
@@ -16,12 +15,6 @@ export interface ExtendedTool extends Tool {
   requiredFields: string[];
   isOpenApiTool: boolean;
 }
-
-export type TransportPayload = {
-  transport: SSEServerTransport;
-  currentJwt: string;
-  cachedTools?: ExtendedTool[];
-};
 
 interface BaseIntegration {
   id: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,10 @@ import { OpenAPIV3 } from "openapi-types";
 
 export const envs = z
   .object({
-    MCP_SERVER_URL: z.string().default(`http://localhost:3001`),
+    MCP_SERVER_URL: z
+      .string()
+      .default("http://localhost:3001")
+      .transform((value) => value || "http://localhost:3001"),
     PROJECT_ID: z.string(),
     SIGNING_KEY: z.string().optional(),
     SIGNING_KEY_PATH: z.string().optional(),
@@ -52,6 +55,12 @@ export const envs = z
           .map((origin) => origin.trim())
           .filter(Boolean)
       ),
+    MCP_SESSION_IDLE_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(30 * 60 * 1000),
+    MCP_MAX_SESSIONS: z.coerce.number().int().positive().default(1000),
     LIMIT_TO_INTEGRATIONS: z
       .string()
       .default("")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,28 @@ export const envs = z
     ENABLE_CUSTOM_OPENAPI_ACTIONS: z.boolean({ coerce: true }).default(false),
     ENABLE_PROXY_API_TOOL: z.boolean({ coerce: true }).default(false),
     ENABLE_CUSTOM_TOOL: z.boolean({ coerce: true }).default(false),
+    ENABLE_LEGACY_SSE: z
+      .enum(["true", "false"])
+      .default("true")
+      .transform((value) => value === "true"),
+    MCP_ALLOWED_HOSTS: z
+      .string()
+      .default("")
+      .transform((value) =>
+        value
+          .split(",")
+          .map((host) => host.trim())
+          .filter(Boolean)
+      ),
+    MCP_ALLOWED_ORIGINS: z
+      .string()
+      .default("")
+      .transform((value) =>
+        value
+          .split(",")
+          .map((origin) => origin.trim())
+          .filter(Boolean)
+      ),
     LIMIT_TO_INTEGRATIONS: z
       .string()
       .default("")

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,13 @@
+import { generateKeyPairSync } from "node:crypto";
+
+const { privateKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+
+process.env.PROJECT_ID = "test-project";
+process.env.SIGNING_KEY = privateKey.export({
+  type: "pkcs8",
+  format: "pem",
+}).toString();
+process.env.NODE_ENV = "production";
+process.env.MCP_SERVER_URL = "http://127.0.0.1";

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -417,6 +417,23 @@ test("chunks authentication expiry timers for long-lived tokens", async (t) => {
   assert.equal(server.getSessionCounts().streamable, 1);
 });
 
+test("chunks long idle expiry timers", async (t) => {
+  const setTimeoutMock = t.mock.method(globalThis, "setTimeout");
+  const server = await startServer(undefined, true, 60 * 24 * 60 * 60 * 1000);
+  await initializeSession(server.baseUrl, signToken("long-idle"));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  const timeoutDelays = setTimeoutMock.mock.calls
+    .map((call) => call.arguments[1])
+    .filter(
+      (delay): delay is number =>
+        typeof delay === "number" && Number.isFinite(delay),
+    );
+  assert.ok(timeoutDelays.includes(2 ** 31 - 1));
+  assert.ok(timeoutDelays.every((delay) => delay <= 2 ** 31 - 1));
+  assert.equal(server.getSessionCounts().streamable, 1);
+});
+
 test("does not expire a session from a stale idle timer", async (t) => {
   const originalConnect = Server.prototype.connect;
   const setTimeoutMock = t.mock.method(globalThis, "setTimeout");
@@ -437,7 +454,14 @@ test("does not expire a session from a stale idle timer", async (t) => {
 
     const idleTimerCall = [...setTimeoutMock.mock.calls]
       .reverse()
-      .find((call) => call.arguments[1] === idleTimeoutMs);
+      .find((call) => {
+        const delay = call.arguments[1];
+        return (
+          typeof delay === "number" &&
+          delay <= idleTimeoutMs &&
+          delay > idleTimeoutMs - 1000
+        );
+      });
     assert.ok(idleTimerCall);
     const idleTimerCallback = idleTimerCall.arguments[0] as () => void;
 

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -6,6 +6,7 @@ import { afterEach, test } from "node:test";
 import { promisify } from "node:util";
 
 import jwt from "jsonwebtoken";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 
 import { createApp } from "../src/index";
 
@@ -24,7 +25,8 @@ function signToken(subject: string): string {
 async function startServer(
   enableLegacySse?: boolean,
   allowListeningHost = true,
-  sessionIdleTimeoutMs = 30 * 60 * 1000
+  sessionIdleTimeoutMs = 30 * 60 * 1000,
+  maxStreamableSessions = 1000,
 ) {
   const allowedHosts: string[] = [];
   const instance = createApp({
@@ -32,13 +34,14 @@ async function startServer(
     allowedHosts,
     allowedOrigins: [],
     sessionIdleTimeoutMs,
+    maxStreamableSessions,
   });
   const server = await new Promise<ReturnType<typeof instance.app.listen>>(
     (resolve) => {
       const listeningServer = instance.app.listen(0, "127.0.0.1", () => {
         resolve(listeningServer);
       });
-    }
+    },
   );
   const address = server.address() as AddressInfo;
   if (allowListeningHost) {
@@ -66,8 +69,8 @@ async function startServer(
   return runningServer;
 }
 
-async function initializeSession(baseUrl: string, token: string) {
-  const response = await fetch(`${baseUrl}/mcp`, {
+function requestSessionInitialization(baseUrl: string, token: string) {
+  return fetch(`${baseUrl}/mcp`, {
     method: "POST",
     headers: {
       Accept: "application/json, text/event-stream",
@@ -88,6 +91,10 @@ async function initializeSession(baseUrl: string, token: string) {
       },
     }),
   });
+}
+
+async function initializeSession(baseUrl: string, token: string) {
+  const response = await requestSessionInitialization(baseUrl, token);
   const responseBody = await response.text();
   assert.equal(response.status, 200, responseBody);
   assert.match(responseBody, /"serverInfo"/);
@@ -97,10 +104,23 @@ async function initializeSession(baseUrl: string, token: string) {
   return sessionId;
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      assert.fail("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 async function sendInitializedNotification(
   baseUrl: string,
   token: string,
-  sessionId: string
+  sessionId: string,
 ) {
   return fetch(`${baseUrl}/mcp`, {
     method: "POST",
@@ -121,7 +141,7 @@ async function sendInitializedNotification(
 async function terminateSession(
   baseUrl: string,
   token: string,
-  sessionId: string
+  sessionId: string,
 ) {
   return fetch(`${baseUrl}/mcp`, {
     method: "DELETE",
@@ -150,7 +170,7 @@ test("handles the stateful Streamable HTTP session lifecycle", async () => {
   const initializedResponse = await sendInitializedNotification(
     server.baseUrl,
     token,
-    sessionId
+    sessionId,
   );
   assert.equal(initializedResponse.status, 202);
 
@@ -165,13 +185,16 @@ test("handles the stateful Streamable HTTP session lifecycle", async () => {
     signal: controller.signal,
   });
   assert.equal(streamResponse.status, 200);
-  assert.match(streamResponse.headers.get("content-type") ?? "", /text\/event-stream/);
+  assert.match(
+    streamResponse.headers.get("content-type") ?? "",
+    /text\/event-stream/,
+  );
   controller.abort();
 
   const deleteResponse = await terminateSession(
     server.baseUrl,
     token,
-    sessionId
+    sessionId,
   );
   assert.equal(deleteResponse.status, 200);
   assert.deepEqual(server.getSessionCounts(), {
@@ -293,14 +316,14 @@ test("authenticates every request and isolates session owners", async () => {
   const wrongOwnerResponse = await sendInitializedNotification(
     server.baseUrl,
     otherToken,
-    sessionId
+    sessionId,
   );
   assert.equal(wrongOwnerResponse.status, 403);
 
   const rotatedTokenResponse = await sendInitializedNotification(
     server.baseUrl,
     rotatedOwnerToken,
-    sessionId
+    sessionId,
   );
   assert.equal(rotatedTokenResponse.status, 403);
 
@@ -334,8 +357,92 @@ test("keeps concurrent Streamable HTTP sessions isolated", async () => {
   ]);
   assert.deepEqual(
     responses.map((response) => response.status),
-    [200, 200]
+    [200, 200],
   );
+});
+
+test("enforces the Streamable HTTP session limit during initialization", async () => {
+  const originalConnect = Server.prototype.connect;
+  let releaseFirstConnect: () => void = () => {};
+  const firstConnectReleased = new Promise<void>((resolve) => {
+    releaseFirstConnect = resolve;
+  });
+  let notifyFirstConnectStarted: () => void = () => {};
+  const firstConnectStarted = new Promise<void>((resolve) => {
+    notifyFirstConnectStarted = resolve;
+  });
+  let connectCalls = 0;
+
+  Server.prototype.connect = async function (transport) {
+    connectCalls += 1;
+    if (connectCalls === 1) {
+      notifyFirstConnectStarted();
+      await firstConnectReleased;
+    }
+    await originalConnect.call(this, transport);
+  };
+
+  try {
+    const server = await startServer(undefined, true, 30 * 60 * 1000, 1);
+    const firstRequest = requestSessionInitialization(
+      server.baseUrl,
+      signToken("first"),
+    );
+    await firstConnectStarted;
+
+    const secondResponse = await requestSessionInitialization(
+      server.baseUrl,
+      signToken("second"),
+    );
+    releaseFirstConnect();
+    const firstResponse = await firstRequest;
+
+    assert.equal(firstResponse.status, 200);
+    assert.equal(secondResponse.status, 503);
+    assert.equal(connectCalls, 1);
+    assert.equal(server.getSessionCounts().streamable, 1);
+  } finally {
+    releaseFirstConnect();
+    Server.prototype.connect = originalConnect;
+  }
+});
+
+test("closes Streamable HTTP resources when connect fails", async () => {
+  const originalConnect = Server.prototype.connect;
+  let serverCloseCalls = 0;
+  let transportCloseCalls = 0;
+
+  Server.prototype.connect = async function (transport) {
+    const originalServerClose = this.close.bind(this);
+    this.close = async () => {
+      serverCloseCalls += 1;
+      await originalServerClose();
+    };
+    const originalTransportClose = transport.close.bind(transport);
+    transport.close = async () => {
+      transportCloseCalls += 1;
+      await originalTransportClose();
+    };
+    transport.start = async () => {
+      throw new Error("forced connect failure");
+    };
+    await originalConnect.call(this, transport);
+  };
+
+  try {
+    const server = await startServer();
+    const response = await requestSessionInitialization(
+      server.baseUrl,
+      signToken("connect-failure"),
+    );
+
+    assert.equal(response.status, 500);
+    assert.equal(serverCloseCalls, 1);
+    assert.equal(transportCloseCalls, 1);
+    assert.equal(server.getSessionCounts().streamable, 0);
+  } finally {
+    Server.prototype.connect = originalConnect;
+  }
 });
 
 test("expires abandoned Streamable HTTP sessions", async () => {
@@ -360,7 +467,10 @@ test("serves legacy SSE by default", async () => {
   });
 
   assert.equal(response.status, 200);
-  assert.match(response.headers.get("content-type") ?? "", /text\/event-stream/);
+  assert.match(
+    response.headers.get("content-type") ?? "",
+    /text\/event-stream/,
+  );
   const reader = response.body!.getReader();
   const firstEvent = await reader.read();
   assert.match(new TextDecoder().decode(firstEvent.value), /event: endpoint/);
@@ -369,6 +479,7 @@ test("serves legacy SSE by default", async () => {
     streamable: 0,
   });
   controller.abort();
+  await waitFor(() => server.getSessionCounts().legacy === 0);
 });
 
 test("removes legacy routes when SSE is explicitly disabled", async () => {
@@ -389,7 +500,7 @@ test("removes legacy routes when SSE is explicitly disabled", async () => {
         "Content-Type": "application/json",
       },
       body: "{}",
-    }
+    },
   );
 
   assert.equal(sseResponse.status, 404);
@@ -413,7 +524,7 @@ test("parses ENABLE_LEGACY_SSE=false without boolean coercion", async () => {
         ENABLE_LEGACY_SSE: "false",
         MCP_SERVER_URL: "",
       },
-    }
+    },
   );
   assert.deepEqual(JSON.parse(stdout), {
     legacy: false,

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 
 import jwt from "jsonwebtoken";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
 import { createApp } from "../src/index";
 
@@ -394,6 +395,83 @@ test("releases session capacity when the initializing token expires", async () =
     signToken("replacement"),
   );
   assert.equal(replacementResponse.status, 200);
+});
+
+test("chunks authentication expiry timers for long-lived tokens", async (t) => {
+  const setTimeoutMock = t.mock.method(globalThis, "setTimeout");
+  const server = await startServer();
+  await initializeSession(
+    server.baseUrl,
+    signToken("long-lived", 60 * 24 * 60 * 60),
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  const timeoutDelays = setTimeoutMock.mock.calls
+    .map((call) => call.arguments[1])
+    .filter(
+      (delay): delay is number =>
+        typeof delay === "number" && Number.isFinite(delay),
+    );
+  assert.ok(timeoutDelays.includes(2 ** 31 - 1));
+  assert.ok(timeoutDelays.every((delay) => delay <= 2 ** 31 - 1));
+  assert.equal(server.getSessionCounts().streamable, 1);
+});
+
+test("does not expire a session from a stale idle timer", async (t) => {
+  const originalConnect = Server.prototype.connect;
+  const setTimeoutMock = t.mock.method(globalThis, "setTimeout");
+  let connectedTransport: StreamableHTTPServerTransport | undefined;
+  let releaseRequest: () => void = () => {};
+
+  Server.prototype.connect = async function (transport) {
+    connectedTransport = transport as StreamableHTTPServerTransport;
+    await originalConnect.call(this, transport);
+  };
+
+  try {
+    const idleTimeoutMs = 123_456;
+    const server = await startServer(undefined, true, idleTimeoutMs);
+    const token = signToken("active-request");
+    const sessionId = await initializeSession(server.baseUrl, token);
+    assert.ok(connectedTransport);
+
+    const idleTimerCall = [...setTimeoutMock.mock.calls]
+      .reverse()
+      .find((call) => call.arguments[1] === idleTimeoutMs);
+    assert.ok(idleTimerCall);
+    const idleTimerCallback = idleTimerCall.arguments[0] as () => void;
+
+    const originalHandleRequest =
+      connectedTransport.handleRequest.bind(connectedTransport);
+    let notifyRequestStarted: () => void = () => {};
+    const requestStarted = new Promise<void>((resolve) => {
+      notifyRequestStarted = resolve;
+    });
+    const requestReleased = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+    connectedTransport.handleRequest = async (req, res, parsedBody) => {
+      notifyRequestStarted();
+      await requestReleased;
+      await originalHandleRequest(req, res, parsedBody);
+    };
+
+    const activeRequest = sendInitializedNotification(
+      server.baseUrl,
+      token,
+      sessionId,
+    );
+    await requestStarted;
+    idleTimerCallback();
+    assert.equal(server.getSessionCounts().streamable, 1);
+
+    releaseRequest();
+    const response = await activeRequest;
+    assert.equal(response.status, 202);
+  } finally {
+    releaseRequest();
+    Server.prototype.connect = originalConnect;
+  }
 });
 
 test("keeps concurrent Streamable HTTP sessions isolated", async () => {

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -1,0 +1,458 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { AddressInfo } from "node:net";
+import { afterEach, test } from "node:test";
+import { promisify } from "node:util";
+
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../src/index";
+
+const activeServers = new Set<Awaited<ReturnType<typeof startServer>>>();
+const execFileAsync = promisify(execFile);
+
+function signToken(subject: string): string {
+  return jwt.sign({}, process.env.SIGNING_KEY!, {
+    algorithm: "RS256",
+    subject,
+    expiresIn: "1h",
+    jwtid: randomUUID(),
+  });
+}
+
+async function startServer(
+  enableLegacySse?: boolean,
+  allowListeningHost = true,
+  sessionIdleTimeoutMs = 30 * 60 * 1000
+) {
+  const allowedHosts: string[] = [];
+  const instance = createApp({
+    enableLegacySse,
+    allowedHosts,
+    allowedOrigins: [],
+    sessionIdleTimeoutMs,
+  });
+  const server = await new Promise<ReturnType<typeof instance.app.listen>>(
+    (resolve) => {
+      const listeningServer = instance.app.listen(0, "127.0.0.1", () => {
+        resolve(listeningServer);
+      });
+    }
+  );
+  const address = server.address() as AddressInfo;
+  if (allowListeningHost) {
+    allowedHosts.push(`127.0.0.1:${address.port}`);
+  }
+
+  const runningServer = {
+    ...instance,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async close() {
+      await instance.closeSessions();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+  activeServers.add(runningServer);
+  return runningServer;
+}
+
+async function initializeSession(baseUrl: string, token: string) {
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: {
+          name: "paragon-mcp-test",
+          version: "1.0.0",
+        },
+      },
+    }),
+  });
+  const responseBody = await response.text();
+  assert.equal(response.status, 200, responseBody);
+  assert.match(responseBody, /"serverInfo"/);
+
+  const sessionId = response.headers.get("mcp-session-id");
+  assert.ok(sessionId);
+  return sessionId;
+}
+
+async function sendInitializedNotification(
+  baseUrl: string,
+  token: string,
+  sessionId: string
+) {
+  return fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "Mcp-Session-Id": sessionId,
+      "MCP-Protocol-Version": "2025-11-25",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+  });
+}
+
+async function terminateSession(
+  baseUrl: string,
+  token: string,
+  sessionId: string
+) {
+  return fetch(`${baseUrl}/mcp`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Mcp-Session-Id": sessionId,
+      "MCP-Protocol-Version": "2025-11-25",
+    },
+  });
+}
+
+afterEach(async () => {
+  await Promise.all([...activeServers].map((server) => server.close()));
+  activeServers.clear();
+});
+
+test("handles the stateful Streamable HTTP session lifecycle", async () => {
+  const server = await startServer();
+  const token = signToken("user-1");
+  const sessionId = await initializeSession(server.baseUrl, token);
+  assert.deepEqual(server.getSessionCounts(), {
+    legacy: 0,
+    streamable: 1,
+  });
+
+  const initializedResponse = await sendInitializedNotification(
+    server.baseUrl,
+    token,
+    sessionId
+  );
+  assert.equal(initializedResponse.status, 202);
+
+  const controller = new AbortController();
+  const streamResponse = await fetch(`${server.baseUrl}/mcp`, {
+    headers: {
+      Accept: "text/event-stream",
+      Authorization: `Bearer ${token}`,
+      "Mcp-Session-Id": sessionId,
+      "MCP-Protocol-Version": "2025-11-25",
+    },
+    signal: controller.signal,
+  });
+  assert.equal(streamResponse.status, 200);
+  assert.match(streamResponse.headers.get("content-type") ?? "", /text\/event-stream/);
+  controller.abort();
+
+  const deleteResponse = await terminateSession(
+    server.baseUrl,
+    token,
+    sessionId
+  );
+  assert.equal(deleteResponse.status, 200);
+  assert.deepEqual(server.getSessionCounts(), {
+    legacy: 0,
+    streamable: 0,
+  });
+});
+
+test("returns protocol errors for missing and unknown sessions", async () => {
+  const server = await startServer();
+  const token = signToken("user-1");
+
+  const missingResponse = await fetch(`${server.baseUrl}/mcp`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  assert.equal(missingResponse.status, 400);
+  assert.equal((await missingResponse.json()).error.code, -32000);
+
+  const unknownResponse = await fetch(`${server.baseUrl}/mcp`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Mcp-Session-Id": "missing-session",
+    },
+  });
+  assert.equal(unknownResponse.status, 404);
+  assert.equal((await unknownResponse.json()).error.code, -32001);
+});
+
+test("returns JSON-RPC parse errors for malformed request bodies", async () => {
+  const server = await startServer();
+  const response = await fetch(`${server.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${signToken("user-1")}`,
+      "Content-Type": "application/json",
+    },
+    body: "{",
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error.code, -32700);
+});
+
+test("returns 415 for unsupported Streamable HTTP content types", async () => {
+  const server = await startServer();
+  const response = await fetch(`${server.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${signToken("user-1")}`,
+      "Content-Type": "text/plain",
+    },
+    body: "{}",
+  });
+
+  assert.equal(response.status, 415);
+  assert.equal((await response.json()).error.code, -32000);
+
+  const encodingResponse = await fetch(`${server.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${signToken("user-1")}`,
+      "Content-Encoding": "compress",
+      "Content-Type": "application/json",
+    },
+    body: "{}",
+  });
+  assert.equal(encodingResponse.status, 415);
+  assert.equal((await encodingResponse.json()).error.code, -32000);
+});
+
+test("cleans up rejected initialization requests", async () => {
+  const server = await startServer();
+  const token = signToken("user-1");
+  const response = await fetch(`${server.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: {
+          name: "paragon-mcp-test",
+          version: "1.0.0",
+        },
+      },
+    }),
+  });
+
+  assert.equal(response.status, 406);
+  assert.deepEqual(server.getSessionCounts(), {
+    legacy: 0,
+    streamable: 0,
+  });
+});
+
+test("authenticates every request and isolates session owners", async () => {
+  const server = await startServer();
+  const ownerToken = signToken("owner");
+  const otherToken = signToken("other");
+  const rotatedOwnerToken = signToken("owner");
+  const sessionId = await initializeSession(server.baseUrl, ownerToken);
+
+  const missingAuthResponse = await fetch(`${server.baseUrl}/mcp`, {
+    headers: {
+      "Mcp-Session-Id": sessionId,
+    },
+  });
+  assert.equal(missingAuthResponse.status, 401);
+
+  const wrongOwnerResponse = await sendInitializedNotification(
+    server.baseUrl,
+    otherToken,
+    sessionId
+  );
+  assert.equal(wrongOwnerResponse.status, 403);
+
+  const rotatedTokenResponse = await sendInitializedNotification(
+    server.baseUrl,
+    rotatedOwnerToken,
+    sessionId
+  );
+  assert.equal(rotatedTokenResponse.status, 403);
+
+  const invalidTokenResponse = await fetch(`${server.baseUrl}/mcp`, {
+    headers: {
+      Authorization: "Bearer invalid",
+      "Mcp-Session-Id": sessionId,
+    },
+  });
+  assert.equal(invalidTokenResponse.status, 401);
+});
+
+test("keeps concurrent Streamable HTTP sessions isolated", async () => {
+  const server = await startServer();
+  const firstToken = signToken("first");
+  const secondToken = signToken("second");
+  const [firstSessionId, secondSessionId] = await Promise.all([
+    initializeSession(server.baseUrl, firstToken),
+    initializeSession(server.baseUrl, secondToken),
+  ]);
+
+  assert.notEqual(firstSessionId, secondSessionId);
+  assert.deepEqual(server.getSessionCounts(), {
+    legacy: 0,
+    streamable: 2,
+  });
+
+  const responses = await Promise.all([
+    terminateSession(server.baseUrl, firstToken, firstSessionId),
+    terminateSession(server.baseUrl, secondToken, secondSessionId),
+  ]);
+  assert.deepEqual(
+    responses.map((response) => response.status),
+    [200, 200]
+  );
+});
+
+test("expires abandoned Streamable HTTP sessions", async () => {
+  const server = await startServer(undefined, true, 20);
+  const token = signToken("idle-user");
+  await initializeSession(server.baseUrl, token);
+  assert.equal(server.getSessionCounts().streamable, 1);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  assert.equal(server.getSessionCounts().streamable, 0);
+});
+
+test("serves legacy SSE by default", async () => {
+  const server = await startServer();
+  const token = signToken("legacy-user");
+  const controller = new AbortController();
+  const response = await fetch(`${server.baseUrl}/sse`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    signal: controller.signal,
+  });
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") ?? "", /text\/event-stream/);
+  const reader = response.body!.getReader();
+  const firstEvent = await reader.read();
+  assert.match(new TextDecoder().decode(firstEvent.value), /event: endpoint/);
+  assert.deepEqual(server.getSessionCounts(), {
+    legacy: 1,
+    streamable: 0,
+  });
+  controller.abort();
+});
+
+test("removes legacy routes when SSE is explicitly disabled", async () => {
+  const server = await startServer(false);
+  const token = signToken("legacy-user");
+
+  const sseResponse = await fetch(`${server.baseUrl}/sse`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const messagesResponse = await fetch(
+    `${server.baseUrl}/messages?sessionId=missing`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    }
+  );
+
+  assert.equal(sseResponse.status, 404);
+  assert.equal(messagesResponse.status, 404);
+});
+
+test("parses ENABLE_LEGACY_SSE=false without boolean coercion", async () => {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      'import { envs } from "./src/utils.ts"; process.stdout.write(JSON.stringify({ legacy: envs.ENABLE_LEGACY_SSE, url: envs.MCP_SERVER_URL }));',
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        ENABLE_LEGACY_SSE: "false",
+        MCP_SERVER_URL: "",
+      },
+    }
+  );
+  assert.deepEqual(JSON.parse(stdout), {
+    legacy: false,
+    url: "http://localhost:3001",
+  });
+});
+
+test("rejects untrusted hosts and origins", async () => {
+  const untrustedHostServer = await startServer(true, false);
+  const token = signToken("user-1");
+
+  const hostResponse = await fetch(`${untrustedHostServer.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: "{}",
+  });
+  assert.equal(hostResponse.status, 403);
+
+  const untrustedOriginServer = await startServer();
+  const originResponse = await fetch(`${untrustedOriginServer.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Origin: "https://untrusted.example",
+    },
+    body: "{}",
+  });
+  assert.equal(originResponse.status, 403);
+});
+
+test("keeps the setup endpoint behavior unchanged", async () => {
+  const server = await startServer();
+  const response = await fetch(`${server.baseUrl}/setup?token=missing`);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Invalid token" });
+});

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -13,11 +13,11 @@ import { createApp } from "../src/index";
 const activeServers = new Set<Awaited<ReturnType<typeof startServer>>>();
 const execFileAsync = promisify(execFile);
 
-function signToken(subject: string): string {
+function signToken(subject: string, expiresInSeconds = 60 * 60): string {
   return jwt.sign({}, process.env.SIGNING_KEY!, {
     algorithm: "RS256",
     subject,
-    expiresIn: "1h",
+    expiresIn: expiresInSeconds,
     jwtid: randomUUID(),
   });
 }
@@ -334,6 +334,66 @@ test("authenticates every request and isolates session owners", async () => {
     },
   });
   assert.equal(invalidTokenResponse.status, 401);
+});
+
+test("lets owners terminate sessions after rotation and rejects expired tokens", async () => {
+  const server = await startServer(undefined, true, 30 * 60 * 1000, 1);
+  const originalToken = signToken("owner");
+  const rotatedToken = signToken("owner");
+  const expiredToken = signToken("owner", -1);
+  const originalSessionId = await initializeSession(
+    server.baseUrl,
+    originalToken,
+  );
+
+  const otherUserDeleteResponse = await terminateSession(
+    server.baseUrl,
+    signToken("other"),
+    originalSessionId,
+  );
+  assert.equal(otherUserDeleteResponse.status, 403);
+  assert.equal(server.getSessionCounts().streamable, 1);
+
+  const expiredDeleteResponse = await terminateSession(
+    server.baseUrl,
+    expiredToken,
+    originalSessionId,
+  );
+  assert.equal(expiredDeleteResponse.status, 401);
+  assert.equal(server.getSessionCounts().streamable, 1);
+
+  const rotatedDeleteResponse = await terminateSession(
+    server.baseUrl,
+    rotatedToken,
+    originalSessionId,
+  );
+  assert.equal(rotatedDeleteResponse.status, 200);
+  assert.equal(server.getSessionCounts().streamable, 0);
+
+  const replacementResponse = await requestSessionInitialization(
+    server.baseUrl,
+    signToken("replacement"),
+  );
+  assert.equal(replacementResponse.status, 200);
+});
+
+test("releases session capacity when the initializing token expires", async () => {
+  const server = await startServer(undefined, true, 30 * 60 * 1000, 1);
+  await initializeSession(server.baseUrl, signToken("expiring", 1));
+
+  const capacityResponse = await requestSessionInitialization(
+    server.baseUrl,
+    signToken("replacement"),
+  );
+  assert.equal(capacityResponse.status, 503);
+
+  await waitFor(() => server.getSessionCounts().streamable === 0, 1500);
+
+  const replacementResponse = await requestSessionInitialization(
+    server.baseUrl,
+    signToken("replacement"),
+  );
+  assert.equal(replacementResponse.status, 200);
 });
 
 test("keeps concurrent Streamable HTTP sessions isolated", async () => {

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -445,6 +445,28 @@ test("closes Streamable HTTP resources when connect fails", async () => {
   }
 });
 
+test("removes Streamable HTTP sessions when the transport closes", async () => {
+  const originalConnect = Server.prototype.connect;
+  let connectedTransport: Parameters<Server["connect"]>[0] | undefined;
+
+  Server.prototype.connect = async function (transport) {
+    connectedTransport = transport;
+    await originalConnect.call(this, transport);
+  };
+
+  try {
+    const server = await startServer();
+    await initializeSession(server.baseUrl, signToken("closed-transport"));
+    assert.equal(server.getSessionCounts().streamable, 1);
+    assert.ok(connectedTransport);
+
+    await connectedTransport.close();
+    await waitFor(() => server.getSessionCounts().streamable === 0);
+  } finally {
+    Server.prototype.connect = originalConnect;
+  }
+});
+
 test("expires abandoned Streamable HTTP sessions", async () => {
   const server = await startServer(undefined, true, 20);
   const token = signToken("idle-user");
@@ -480,6 +502,45 @@ test("serves legacy SSE by default", async () => {
   });
   controller.abort();
   await waitFor(() => server.getSessionCounts().legacy === 0);
+});
+
+test("cleans up legacy SSE resources when connect fails", async () => {
+  const originalConnect = Server.prototype.connect;
+  let serverCloseCalls = 0;
+  let transportCloseCalls = 0;
+
+  Server.prototype.connect = async function (transport) {
+    const originalServerClose = this.close.bind(this);
+    this.close = async () => {
+      serverCloseCalls += 1;
+      await originalServerClose();
+    };
+    const originalTransportClose = transport.close.bind(transport);
+    transport.close = async () => {
+      transportCloseCalls += 1;
+      await originalTransportClose();
+    };
+    transport.start = async () => {
+      throw new Error("forced legacy connect failure");
+    };
+    await originalConnect.call(this, transport);
+  };
+
+  try {
+    const server = await startServer();
+    const response = await fetch(`${server.baseUrl}/sse`, {
+      headers: {
+        Authorization: `Bearer ${signToken("legacy-connect-failure")}`,
+      },
+    });
+
+    assert.equal(response.status, 500);
+    assert.equal(serverCloseCalls, 1);
+    assert.equal(transportCloseCalls, 1);
+    assert.equal(server.getSessionCounts().legacy, 0);
+  } finally {
+    Server.prototype.connect = originalConnect;
+  }
 });
 
 test("removes legacy routes when SSE is explicitly disabled", async () => {
@@ -543,7 +604,7 @@ test("rejects untrusted hosts and origins", async () => {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: "{}",
+    body: "{",
   });
   assert.equal(hostResponse.status, 403);
 
@@ -556,9 +617,22 @@ test("rejects untrusted hosts and origins", async () => {
       "Content-Type": "application/json",
       Origin: "https://untrusted.example",
     },
-    body: "{}",
+    body: "{",
   });
   assert.equal(originResponse.status, 403);
+});
+
+test("authenticates MCP requests before parsing JSON bodies", async () => {
+  const server = await startServer();
+  const response = await fetch(`${server.baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: "{",
+  });
+
+  assert.equal(response.status, 401);
 });
 
 test("keeps the setup endpoint behavior unchanged", async () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add authenticated, stateful Streamable HTTP at `GET`/`POST`/`DELETE /mcp`
- create isolated MCP server, JWT context, and tool cache per session
- preserve `/sse` and `/messages` by default; remove them with `ENABLE_LEGACY_SSE=false`
- add host/origin validation, session capacity and idle expiry, protocol-compliant errors, and lifecycle cleanup
- upgrade `@modelcontextprotocol/sdk` to stable v1.29.0

## Compatibility and deployment impacts
- existing legacy SSE clients continue working unless explicitly disabled
- Streamable HTTP clients must retain the initialization token and send it on every request; rotated tokens require a new session
- sessions are in memory, expire after 30 minutes by default, and require sticky routing across multiple instances
- alternate public hosts/origins must be listed in `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` when they differ from `MCP_SERVER_URL`

## Validation
- `npm run typecheck`
- `npm test` (13 passing transport/session tests)
- `npm run build`
- `git diff --check`

Docker image validation could not run because Docker is not installed in the agent environment; the production esbuild bundle completed successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6a71721-91e9-4d2e-a348-466e9ee7a138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6a71721-91e9-4d2e-a348-466e9ee7a138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

